### PR TITLE
data is urlencoded and encoded into utf-8 before passing to urlopen

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -32,10 +32,10 @@ def sendKey(url, key, suffix, verbose):
 
     if verbose:
         print "url : " + url
-
+    data = urllib.parse.urlencode(data).encode('utf-8')
     request = urllib2.Request(full_url, data, {'Content-Type': content_type, 'Content-Length': clen})
     request.get_method = lambda: method
-    
+   
     try:    
         resp = urllib2.urlopen(request)
         rcode = resp.getcode()


### PR DESCRIPTION
When urllib2.urlopen is called without encoding the following exception is raised : TypeError: ```POST data should be bytes or an iterable of bytes. It cannot be of type str```
The encoding fixes this issue.